### PR TITLE
delay on timer play button toggle removed by setting state twice

### DIFF
--- a/lib/screens/timer_page.dart
+++ b/lib/screens/timer_page.dart
@@ -61,18 +61,23 @@ class _TimerPageState extends State<TimerPage> with TickerProviderStateMixin {
   }
 
   void start() {
+    setState(() {
+      playPauseIcon = Icon(Icons.pause);
+    });
+    
     _everySecondTimer = Timer.periodic(Duration(seconds: 1), (Timer t) {
-      setState(() {
-        playPauseIcon = Icon(Icons.pause);
-        accumulatedSeconds++;
-        int delta = segmentTime - accumulatedSeconds;
-        if (delta <= 0) {
-          transition();
-        }
-        if (delta == 30) {
-          playChime('../../assets/sounds/chime.mp3');
-        }
-      });
+
+      accumulatedSeconds++;
+      
+      int delta = segmentTime - accumulatedSeconds;
+      if (delta <= 0) {
+        transition();
+      }
+      if (delta == 30) {
+        playChime('../../assets/sounds/chime.mp3');
+      }
+
+      setState(() {});
     });
   }
 


### PR DESCRIPTION
Used two calls to set state in start() to eliminate delay on toggle to pause icon